### PR TITLE
initial fork from CF (0.12.2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
 requirements:
   host:
     - pip
+    - setuptools
+    - wheel
     - python >=3.6
   run:
     - liac-arff >=2.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ test:
   commands:
     - pip check
     - openml --help
+    # disabled because tests not packaged with source
+    #- cd tests && pytest
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,7 @@ source:
 build:
   number: 0
   noarch: python
-  entry_points:
-    - openml=openml.cli:main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
@@ -27,7 +25,7 @@ requirements:
     - numpy >=1.6.2
     - pandas >=1.0.0
     - pyarrow
-    - python >=3.6
+    - python
     - python-dateutil
     - requests
     - scikit-learn >=0.18


### PR DESCRIPTION
currently waiting for liac-arff and minio

* [x] upstream repo https://github.com/openml/openml-python
* [x] go through [changelog](https://github.com/openml/openml-python/releases)
* [x] dev_url, doc_url valid
* [x] check license is accurate
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream
```
meta.yaml
    - liac-arff >=2.4.0
    - minio
    - numpy >=1.6.2
    - pandas >=1.0.0
    - pyarrow
    - python
    - python-dateutil
    - requests
    - scikit-learn >=0.18
    - scipy >=0.13.3
    - xmltodict

setup.cfg
        "liac-arff>=2.4.0",
        "xmltodict",
        "requests",
        "scikit-learn>=0.18",
        "python-dateutil",  # Installed through pandas anyway.
        "pandas>=1.0.0",
        "scipy>=0.13.3",
        "numpy>=1.6.2",
        "minio",
        "pyarrow",
```
