### PR TITLE
PKG-8913: openml 0.15.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/minio-feedstock/pr2/28cab8d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/minio-feedstock/pr2/28cab8d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,32 +7,36 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openml-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: cefb4792ca12ee87ab3acc5e5afb4e9d205c398621e2424f2f5de1564cfee849
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  entry_points:
+    - openml=openml.cli:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<36]
 
 requirements:
   host:
     - pip
+    - python >=3.6
     - setuptools
     - wheel
-    - python >=3.6
   run:
+    - python >=3.6
     - liac-arff >=2.4.0
-    - minio
-    - numpy >=1.6.2
-    - pandas >=1.0.0
-    - pyarrow
-    - python
-    - python-dateutil
+    - xmltodict
     - requests
     - scikit-learn >=0.18
+    - python-dateutil
+    - pandas >=1.0.0
     - scipy >=0.13.3
-    - xmltodict
+    - minio
+    # AttributeError: `np.sctypes` was removed in the NumPy 2.0 release. Access dtypes explicitly instead.
+    - numpy >=1.6.2,<2
+    - pyarrow
 
 test:
   imports:
@@ -41,18 +45,21 @@ test:
   commands:
     - pip check
     - openml --help
-    # disabled because tests not packaged with source
-    #- cd tests && pytest
   requires:
     - pip
 
 about:
-  home: https://openml.org/
+  home: https://openml.org
   summary: Python API for OpenML
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  description: |
+    OpenML-Python provides an easy-to-use and straightforward Python interface for OpenML,
+    an online platform for open science collaboration in machine learning.
+    It can download or upload data from OpenML, such as datasets and machine learning experiment results.
   dev_url: https://github.com/openml/openml-python
-  doc_url: https://openml.github.io/openml-python/
+  doc_url: https://openml.github.io/openml-python
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "openml" %}
-{% set version = "0.12.2" %}
-
+{% set version = "0.15.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,24 +7,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cefb4792ca12ee87ab3acc5e5afb4e9d205c398621e2424f2f5de1564cfee849
+  sha256: 58ae3840b6ea736bb6c69bcbb30d587b817f64db070dc691adb9e09b99018816
 
 build:
-  number: 1
-  noarch: python
+  number: 0
   entry_points:
-    - openml=openml.cli:main
+    - openml = openml.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<36]
+  skip: True  # [py<38]
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools
+    - python
     - wheel
+    - setuptools >=61.0
   run:
-    - python >=3.6
+    - python
     - liac-arff >=2.4.0
     - xmltodict
     - requests
@@ -33,15 +31,35 @@ requirements:
     - python-dateutil
     - pandas >=1.0.0
     - scipy >=0.13.3
+    - numpy >=1.6.2
     - minio
-    # AttributeError: `np.sctypes` was removed in the NumPy 2.0 release. Access dtypes explicitly instead.
-    - numpy >=1.6.2,<2
     - pyarrow
+    - tqdm
+    - packaging
+    # ModuleNotFoundError: No module named 'typing_extensions'
+    # https://github.com/openml/openml-python/blob/v0.15.1/openml/datasets/dataset.py#L12
+    # typing_extensions must be in the run section
+    - typing_extensions
 
 test:
   imports:
     - openml
+    - openml._api_calls
+    - openml.base
+    - openml.config
     - openml.datasets
+    - openml.evaluations
+    - openml.exceptions
+    - openml.extensions
+    - openml.extensions.sklearn
+    - openml.flows
+    - openml.flows.flow
+    - openml.runs
+    - openml.runs.trace
+    - openml.setups
+    - openml.study.study
+    - openml.tasks
+    - openml.utils
   commands:
     - pip check
     - openml --help


### PR DESCRIPTION
openml 0.12.2

**Destination channel:** defaults

### Links

- [PKG-8913](https://anaconda.atlassian.net/browse/PKG-8913) 
- [Upstream repository](https://github.com/openml/openml-python/tree/v0.15.1)

### Explanation of changes:

- Fix the downstream in scikit-learn


[PKG-8913]: https://anaconda.atlassian.net/browse/PKG-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ